### PR TITLE
workaround: network paths for guessit

### DIFF
--- a/couchpotato/core/plugins/scanner.py
+++ b/couchpotato/core/plugins/scanner.py
@@ -918,7 +918,7 @@ class Scanner(Plugin):
         guess = {}
         if file_name:
             try:
-                guessit = guess_movie_info(toUnicode(file_name))
+                guessit = guess_movie_info(toUnicode(file_name.replace('\\\\', 'C:\\')))
                 if guessit.get('title') and guessit.get('year'):
                     guess = {
                         'name': guessit.get('title'),


### PR DESCRIPTION
Guessit seems to get hung up with network paths.
Replacing the \ with C:\ seems to do the trick

Not sure how this will affect other platforms though, testing needed.

Fixes #4128 (couldn't find the referenced report in the close message)
